### PR TITLE
Seguir mostrando los eventos del dia en Home

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -12,7 +12,7 @@ class HomeController < ApplicationController
     @current_events = []
     Event.all.order(:start).each do |e|
       # Muestra eventos dentro de los próximos 15 días
-      @events.push(e) if (e.end || e.start+90.minutes).between?(Time.current, Time.current + 15.days)
+      @events.push(e) if (e.end || e.start+90.minutes).between?(Time.zone.today, Time.zone.today + 15.days)
 
       # Lógica para mostrar o no el popup
 


### PR DESCRIPTION
Como se estaba usando Time.current, para mostrar los eventos en el calendario de Home, una vez que ya pasaron ya no se encontraban ahi, y buscarlos en el select list de Registro es mas dificil :sweat_smile:

Que piensan? Esta bien asi o de plano no deberia salir ahi si ya paso? (No se como cambie esto otras cosas)